### PR TITLE
Change here-string bashism to POSIX echo

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -653,7 +653,7 @@ if test "$have_amd_opt" = yes && test "${enable_debug+set}" != "set" && test "$I
         AC_DEFINE(AMD_DYNAMIC_DISPATCHER,1,[Define to enable AMD dynamic dispatcher feature that would build a single portable optimized library which can execute on different x86 CPU architectures.])
         
         SUBSTRGCC='gcc'
-        if grep -q "$SUBSTRGCC" <<<"$CC"; then		
+        if echo "$CC" | grep -q "$SUBSTRGCC"; then		
         	CFLAGS="$CFLAGS -mno-avx256-split-unaligned-store -mno-avx256-split-unaligned-load -mno-prefer-avx128"
         else
             AC_MSG_CHECKING([whether we are using clang 14 or later])
@@ -683,13 +683,13 @@ if test "$have_amd_opt" = yes && test "${enable_debug+set}" != "set" && test "$I
 		fi
 		SUBSTRCLANG='clang'
 		SUBSTRGCC='gcc'
-		if grep -q "$SUBSTRCLANG" <<<"$CC"; then
+		if echo "$CC" | grep -q "$SUBSTRCLANG"; then
 			if [[ -z "${AMD_ARCH}" ]]; then
 				CFLAGS="$CFLAGS -mavx2 -mfma"
 			else
 				CFLAGS="$CFLAGS -march=$AMD_ARCH -mavx2 -mfma"
 			fi
-		elif grep -q "$SUBSTRGCC" <<<"$CC"; then
+		elif echo "$CC" | grep -q "$SUBSTRGCC"; then
 			GCCVERSION=$(expr `gcc -dumpversion | cut -f1 -d.`)
 			case "$AMDZENFAMILY" in
 				"23") 


### PR DESCRIPTION
The `<<<` syntax is not POSIX and won't work on systems where `sh` cares about such niceties (mostly dash). Replace it with a simple `echo` to get things to work. Note that grepping the CC substring for `gcc` and `clang` is probably not a good way of doing these feature checks to begin with (and some flags are duplicated) since `AX_CHECK_COMPILER_FLAGS` is a thing, but that's left as an exercise to the reader.

Note that `configure` has to be regenerated with `autoconf` before this sticks. I haven't made this part of my commit since it causes a *lot* of churn.