### PR TITLE
fix(tools): fix NULL pointer dereference in output_fname allocation and set output_fname to NULL after freeing to prevent dangling pointer

### DIFF
--- a/tools/fftw-wisdom.c
+++ b/tools/fftw-wisdom.c
@@ -223,6 +223,12 @@ int bench_main(int argc, char *argv[])
 		   else {
 			output_fname = (char *) bench_malloc(sizeof(char) *
 						    (strlen(my_optarg) + 1));
+							
+			/* Check for allocation failure to prevent NULL pointer dereference */
+        	if (!output_fname) {
+            	fprintf(stderr, "fftw-wisdom: out of memory\n");
+            	exit(EXIT_FAILURE);
+        	}
 			strcpy(output_fname, my_optarg);
 		   }
 		   break;

--- a/tools/fftw-wisdom.c
+++ b/tools/fftw-wisdom.c
@@ -215,15 +215,16 @@ int bench_main(int argc, char *argv[])
 		   break;
 
 	      case 'o':
-		   if (output_fname)
+		   if (output_fname){
 			bench_free(output_fname);
-		   
+			output_fname = NULL;
+		   }
 		   if (!strcmp(my_optarg, "-"))
 			output_fname = 0;
 		   else {
 			output_fname = (char *) bench_malloc(sizeof(char) *
 						    (strlen(my_optarg) + 1));
-							
+
 			/* Check for allocation failure to prevent NULL pointer dereference */
         	if (!output_fname) {
             	fprintf(stderr, "fftw-wisdom: out of memory\n");


### PR DESCRIPTION
# Description
This PR fixes a potential NULL pointer dereference vulnerability in `fftw-wisdom.c` (or benchmark utility) inside the handling of the `-o` flag.

# Missing validation
The current implementation calls `strcpy(output_fname, my_optarg);` immediately after calling `bench_malloc()`, without verifying if the memory allocation succeeded. If `bench_malloc` returns `NULL` due to memory exhaustion, it causes a crash (Segmentation Fault).

# Changes
- Added a validation check right after `bench_malloc`.
- Handles allocation failure by printing an error and exiting gracefully.
- Explicitly nullified `output_fname` after `bench_free` to avoid potential dangling pointer issues.